### PR TITLE
Use sha256 digest for base image instead of version tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Build container
-ARG GOVERSION=1.25
+ARG GOVERSION=1.26
 ARG ALPINEVERSION
 
 FROM --platform=${BUILDPLATFORM} \
-    golang@sha256:98e6cffc31ccc44c7c15d83df1d69891efee8115a5bb7ede2bf30a38af3e3c92 AS build
+    golang@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS build
 
 WORKDIR /src
 RUN apk --no-cache add git build-base bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # Build container
-ARG GOVERSION=1.25
-ARG ALPINEVERSION
+ARG GOVERSION=1.25.6
+ARG ALPINEVERSION=3.23
+ARG GOHASH=98e6cffc31ccc44c7c15d83df1d69891efee8115a5bb7ede2bf30a38af3e3c92
 
 FROM --platform=${BUILDPLATFORM} \
-    golang:$GOVERSION-alpine${ALPINEVERSION} AS build
+    golang@sha256:${GOHASH} AS build
 
 WORKDIR /src
 RUN apk --no-cache add git build-base bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 # Build container
-ARG GOVERSION=1.25.6
-ARG ALPINEVERSION=3.23
-ARG GOHASH=98e6cffc31ccc44c7c15d83df1d69891efee8115a5bb7ede2bf30a38af3e3c92
+ARG GOVERSION=1.25
+ARG ALPINEVERSION
 
 FROM --platform=${BUILDPLATFORM} \
-    golang@sha256:${GOHASH} AS build
+    golang@sha256:98e6cffc31ccc44c7c15d83df1d69891efee8115a5bb7ede2bf30a38af3e3c92 AS build
 
 WORKDIR /src
 RUN apk --no-cache add git build-base bash

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -18,11 +18,16 @@ variable "ALPINEVERSION" {
     default = "3.23"
 }
 
+variable "GOHASH" {
+    default = "98e6cffc31ccc44c7c15d83df1d69891efee8115a5bb7ede2bf30a38af3e3c92"
+}
+
 target "default" {
     args = {
         VERSION = CLOUDFLARED_VERSION
         GOVERSION = GOVERSION
         ALPINEVERSION = ALPINEVERSION
+        GOHASH = GOHASH
     }
     platforms = !MULTI_PLATFORM ? null : [
         "linux/amd64",

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -18,16 +18,11 @@ variable "ALPINEVERSION" {
     default = "3.23"
 }
 
-variable "GOHASH" {
-    default = "98e6cffc31ccc44c7c15d83df1d69891efee8115a5bb7ede2bf30a38af3e3c92"
-}
-
 target "default" {
     args = {
         VERSION = CLOUDFLARED_VERSION
         GOVERSION = GOVERSION
         ALPINEVERSION = ALPINEVERSION
-        GOHASH = GOHASH
     }
     platforms = !MULTI_PLATFORM ? null : [
         "linux/amd64",

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -11,7 +11,7 @@ variable "MULTI_PLATFORM" {
 }
 
 variable "GOVERSION" {
-    default = "1.25.6"
+    default = "1.26"
 }
 
 variable "ALPINEVERSION" {


### PR DESCRIPTION
Replaced version-based Docker image tag with sha256 digest to ensure immutability and improve security.

Fixes #22